### PR TITLE
Update path replacement command to be more reliable

### DIFF
--- a/commands/build
+++ b/commands/build
@@ -12,9 +12,8 @@ GCC_LIB="SR_ANDROID_${SR_ARCH}_GCC_LIB"
 
 ####### SwiftGlibc HAS A HARDCODED PATH
 
-cat /root/swift-install/usr/lib/swift/android/armv7/glibc.modulemap \
-	| sed 's/\/root\/ndk\/android-ndk-r14b\/platforms\/android-21\/arch-arm\//\/root\/android-standalone-toolchain\/sysroot/g' \
-	> /root/swift-install/usr/lib/swift/android/armv7/glibc.modulemap
+sed -i "s_/root/ndk/android-ndk-r14b/platforms/android-21/arch-arm/_/root/android-standalone-toolchain/sysroot_g" \
+    /root/swift-install/usr/lib/swift/android/armv7/glibc.modulemap
 
 ####### /SwiftGlibc HAS A HARDCODED PATH
 

--- a/commands/swiftc
+++ b/commands/swiftc
@@ -10,6 +10,13 @@ TOOLCHAIN="SR_ANDROID_${SR_ARCH}_TOOLCHAIN"
 SDK="SR_ANDROID_${SR_ARCH}_SDK"
 GCC_LIB="SR_ANDROID_${SR_ARCH}_GCC_LIB"
 
+####### SwiftGlibc HAS A HARDCODED PATH
+
+sed -i "s_/root/ndk/android-ndk-r14b/platforms/android-21/arch-arm/_/root/android-standalone-toolchain/sysroot_g" \
+    /root/swift-install/usr/lib/swift/android/armv7/glibc.modulemap
+
+####### /SwiftGlibc HAS A HARDCODED PATH
+
 $SR_SWIFT_BIN/swiftc \
     -target $SR_TRIPLE \
     -tools-directory ${!TOOLCHAIN}/bin \


### PR DESCRIPTION
The existing use of `sed` to fix the Glibc paths fails at least 50% of the time (probably due to some docker weirdness) leading to cryptic errors while building. This happens on multiple machines (with presumably various docker versions). This new approach appears to work 100% of the time.

Also adds the `sed` replacement to `sr swiftc`