### PR TITLE
Mounts the host filesystem at /root/host_fs in `sr shell`

### DIFF
--- a/util/functions.sh
+++ b/util/functions.sh
@@ -53,7 +53,7 @@ function sr_run {
 }
 
 function sr_shell {
-    sr_call_docker run --rm -ti $SR_IMAGE /bin/bash -l $@
+    sr_call_docker run --rm -v /:$SR_HOST_FS -w="$SR_HOST_FS`pwd`" -ti $SR_IMAGE /bin/bash -l $@
 }
 
 ### Commands ###


### PR DESCRIPTION
Makes the `sr shell` environment the same as the one used by `sr swiftc` and `sr build`